### PR TITLE
docs: fix simple typo, recieve -> receive

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -35,7 +35,7 @@ e.g.: ureq_serve("/", s_home, GET);
 */
 
 char *s_home() {
-    /* That's the most basic example. In this case, client will recieve
+    /* That's the most basic example. In this case, client will receive
      * text/html response containing only "home" string. */
     return "home";
 }


### PR DESCRIPTION
There is a small typo in examples/example.c.

Should read `receive` rather than `recieve`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md